### PR TITLE
Small Change in " Create Storage Engine " section

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ conn.once('open', () => {
 
 // Create storage engine
 const storage = new GridFsStorage({
-  url: monogoURI,
+  url: mongoURI,
   file: (req, file) => {
     return new Promise((resolve, reject) => {
       crypto.randomBytes(16, (err, buf) => {


### PR DESCRIPTION
In this section , GridFsStorage take up object of url as key . I have improved spelling mistake of mongodb . i.e { url : mongodb } in case you have written { url : monogoURI }.
Will you accept the changes ? Thanks for providing this tutorial . It is very helpful to me.